### PR TITLE
Add csmonitor text edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of lightweight websites for news and other things
 - http://cbc.ca/lite
 - https://lite.cnn.com/en
 - https://text.npr.org
+- https://www.csmonitor.com/layout/set/text/textedition
 
 ## Other
 - https://old.reddit.com/


### PR DESCRIPTION
Has the added benefit that you can convert a normal csmonitor link to a text link by adding /layout/set/text/ to the start of the path